### PR TITLE
修改member分片问题

### DIFF
--- a/spring-boot-sharding -jdbc/ src/ main/ resources/ config/ spring/spring-sharding-member.xml
+++ b/spring-boot-sharding -jdbc/ src/ main/ resources/ config/ spring/spring-sharding-member.xml
@@ -37,7 +37,7 @@
       
     <!-- t_member 分表策略 -->  
     <bean id="memberTableShardingStrategy" class="com.dangdang.ddframe.rdb.sharding.api.strategy.table.TableShardingStrategy">  
-        <constructor-arg index="0" value="strategy"/>  
+        <constructor-arg index="0" value="STRATEGY"/>  
         <constructor-arg index="1">  
             <bean class="com.lwl.boot.sharding.jdbc.algorithm.MemberSingleKeyTableShardingAlgorithm" />  
         </constructor-arg>  


### PR DESCRIPTION
由于分片键大小写，导致匹配不到，同时插入多个数据表。